### PR TITLE
Parse workspace name when geometry is unavailable

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,10 +28,11 @@ class KeywordQueryEventListener(EventListener):
         result = subprocess.run(['wmctrl -l | awk \'{ if( $2 != "-1") { $3="";  print $0} }\''], capture_output=True, shell=True, text=True).stdout
         w_list = [y for y in (x.strip() for x in result.splitlines()) if y]
         w_dict = {x[1].split(maxsplit=2)[0]: {'ws': int(x[1].split(maxsplit=2)[1]), 'name': x[1].split(maxsplit=2)[2]} for x in enumerate(w_list)}
-        
+
         # Get list of all workspaces and process into a dictionary that looks like this:
         # {<workspace_id>: <workspace_name>}
-        result = subprocess.run(['wmctrl -d | awk \'{$1=$2=$3=$4=$5=$6=$7=$8=$9=""; print $0}\''], capture_output=True, shell=True, text=True).stdout
+        result = subprocess.run(["wmctrl -d | sed -n -E -e 's/^.*WA: (N\/A|.,. [[:digit:]]+x[[:digit:]]+)  //p'"],
+            capture_output=True, shell=True, text=True).stdout
         ws_list = [y for y in (x.strip() for x in result.splitlines()) if y]
         ws_dict = {i: x for i, x in enumerate(ws_list)}
 
@@ -40,7 +41,7 @@ class KeywordQueryEventListener(EventListener):
                 items.append(ExtensionResultItem(icon='images/window.svg',
                                                 # Workaround for https://github.com/Ulauncher/Ulauncher/issues/587
                                                 name=window['name'].replace('&', '&amp;') if search else window['name'],
-                                                description=f'Workspace: {window["ws"]}: {ws_dict[window["ws"]]}, Window Id: {w_idx}',
+                                                description=f'Workspace {window["ws"]}: {ws_dict[window["ws"]]}, Window Id: {w_idx}',
                                                 on_enter=RunScriptAction(f'wmctrl -ia {w_idx}')))
 
         return RenderResultListAction(items)


### PR DESCRIPTION
The workspace information contains one column fewer when the workspace
geometry is unavailable, which previously broke the retrieval of the
workspace name.

The name should now be retrieved correctly in both cases and with an
arbitrary number of spaces between the columns of `wmctrl -d`.