### PR TITLE
Make file compatible with Python 3.5+

### DIFF
--- a/main.py
+++ b/main.py
@@ -41,9 +41,9 @@ class KeywordQueryEventListener(EventListener):
         # {<window_id>: {ws: <workspace_id>, name: <window_name>}}
         result = subprocess.run(
             ['wmctrl -l | awk \'{ if( $2 != "-1") { $3="";  print $0} }\''],
-            capture_output=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, # equivalent to capture_output=True
             shell=True,
-            text=True,
+            universal_newlines=True, # equivalent to text=True
         ).stdout
         w_list = [y for y in (x.strip() for x in result.splitlines()) if y]
         w_dict = {
@@ -60,9 +60,9 @@ class KeywordQueryEventListener(EventListener):
             [
                 "wmctrl -d | sed -n -E -e 's/^.*WA: (N\/A|.,. [[:digit:]]+x[[:digit:]]+)  //p'"
             ],
-            capture_output=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE, # equivalent to capture_output=True
             shell=True,
-            text=True,
+            universal_newlines=True, # equivalent to text=True
         ).stdout
         ws_list = [y for y in (x.strip() for x in result.splitlines()) if y]
         ws_dict = {i: x for i, x in enumerate(ws_list)}


### PR DESCRIPTION
fixes #5

With this fix, the extension also works on Ubuntu 16.04, using Python 3.5+.

see: https://docs.python.org/3/library/subprocess.html