### PR TITLE
fix regex for workspace retrieval (Loading issue in Fedora)

### DIFF
--- a/main.py
+++ b/main.py
@@ -59,7 +59,7 @@ class KeywordQueryEventListener(EventListener):
         # {<workspace_id>: <workspace_name>}
         result = subprocess.run(
             [
-                "wmctrl -d | sed -n -E -e 's/^.*WA: (N\/A|.,. [[:digit:]]+x[[:digit:]]+)  //p'"
+                "wmctrl -d | sed -n -E -e 's/^.*WA: (N\/A|.+,.+ [[:digit:]]+x[[:digit:]]+)  //p'"
             ],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,  # equivalent to capture_output=True


### PR DESCRIPTION
Hi,

I have this same issue as in #11 and it seems just a minor tweak is needed.

I have tested it only on Fedora, but this just adds support for more chars and should not break existing functionality:

![image](https://user-images.githubusercontent.com/2995233/165491299-bff91624-fe8a-46d7-b875-0dc5444ace6f.png)

```zsh
$ wmctrl -d | sed -n -E -e 's/^.*WA: (N\/A|.+,.+ [[:digit:]]+x[[:digit:]]+)  //p'
Workspace 1

N/A
```